### PR TITLE
Fix banPlayer rcon command

### DIFF
--- a/arc.php
+++ b/arc.php
@@ -546,7 +546,7 @@ class ARC
      */
     public function banPlayer($player, $reason = 'Banned', $time = 0)
     {
-        if (!is_int($player) || !is_string($reason) || !is_int($time)) {
+        if (!is_string($player) || !is_string($reason) || !is_int($time)) {
             throw new \Exception('Wrong parameter type!');
         }
 


### PR DESCRIPTION
Check for int when the server needs a GUID (which is not fully integer) is wrong and makes this function useless.
