### PR TITLE
Add new option `autosaveBans`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ try {
 Options can be passed to ARC as an array via the fourth parameter of the constructor. The following options are currently available:
 * `bool sendHeartbeat = false`: Sends a heartbeat packet to the server *(will be deprecated in v2.2)*.
 * `int timeoutSec = 1`: Sets a timeout value on the connection.
+* `bool autosavebans = false`: Auto save bans.txt when an player is banned or unbanned.
 
 *Suggestions for new options are always welcome!* :+1: <br>
 

--- a/arc.php
+++ b/arc.php
@@ -563,6 +563,7 @@ class ARC
         }
 
         $this->send("ban $player $time $reason");
+        $this->writeBans();
         $this->reconnect();
         
         return $this;
@@ -586,6 +587,7 @@ class ARC
         }
 
         $this->send("addBan $player $time $reason");
+        $this->writeBans();
         return $this;
     }
 
@@ -607,6 +609,7 @@ class ARC
         }
 
         $this->send("removeBan $banId");
+        $this->writeBans();
         return $this;
     }
 

--- a/arc.php
+++ b/arc.php
@@ -23,6 +23,7 @@ class ARC
     private $options = [
         'sendHeartbeat' => false,
         'timeoutSec'    => 1,
+        'autosavebans'  => false,
     ];
 
     /**
@@ -563,9 +564,12 @@ class ARC
         }
 
         $this->send("ban $player $time $reason");
-        $this->writeBans();
         $this->reconnect();
         
+        if ($this->options['autosavebans']) {
+            $this->writeBans();
+        }
+
         return $this;
     }
 
@@ -587,7 +591,11 @@ class ARC
         }
 
         $this->send("addBan $player $time $reason");
-        $this->writeBans();
+        
+        if ($this->options['autosavebans']) {
+            $this->writeBans();
+        }
+        
         return $this;
     }
 
@@ -609,7 +617,11 @@ class ARC
         }
 
         $this->send("removeBan $banId");
-        $this->writeBans();
+       
+        if ($this->options['autosavebans']) {
+            $this->writeBans();
+        }
+        
         return $this;
     }
 


### PR DESCRIPTION
Its not an bug, but more nice of us to do.

If you forget $this->writeBans(); after an ban, the bans.txt will not save the ban when the server restarts and you bans.txt will be empty or the player you banned is not there anymore