### PR TITLE
Fixing -1ms ping players not getting detected

### DIFF
--- a/arc.php
+++ b/arc.php
@@ -512,7 +512,7 @@ class ARC
         $playersRaw = $this->getPlayers();
 
         $players = $this->cleanList($playersRaw);
-        preg_match_all("#(\d+)\s+(\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d+\b)\s+(\d+)\s+([0-9a-fA-F]+)\(\w+\)\s([\S ]+)$#im", $players, $str);
+        preg_match_all("#(\d+)\s+(\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d+\b)\s+\-*(\d+)\s+([0-9a-fA-F]+)\(\w+\)\s([\S ]+)$#im", $players, $str);
         
         return $this->formatList($str);
     }


### PR DESCRIPTION
When a player joins the server, BattlEye will output a ping of "-1" for a few seconds. If you request the player list at this point, the player will be missing, as the Regex will not detect the negative digit.

While this might not be too relevant for a PHP use case, it is still nice to have it fixed :)
I have used your code in a few projects now, and have now finally built it into my Java RCON Client for AllianceApps - while I fixed this bug a few years ago in PHP, I ran into it again and thought I should probably fix it here, too :)


Quick note in the PR: I have changed the Regex in a way that it ignores the minus and just outputs 1 as ping. You could also put it into the group brackets to have it included, but it doesn't really matter THAT much (as BE ping is bullshit anyway).